### PR TITLE
Jay

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,3 +47,38 @@
 * Upon scrolling on ProjectList all projects "Glow". 
 
 * Bring Keyboard up at same time as as modal, eliminating the step of pressing the input to bring the keyboard up
+
+* 
+WhichSignUpScreen 
+PilotSignUpScreen 
+ClientSignUpScreen
+Either make page static without <ScrollView> if possible, or stop the scroll "overlap after scrolling" from showing the White Background. Should scroll no further that the background image
+
+* 
+PilotSignUpScreen
+ClientSignUpScreen
+Sign Up Button as opposed to text??
+
+* Mysterious "doesn't load upon SignUp unless you tap the white, blank screen" issue
+
+* CSS on AboutScreen is jacked on iPhone 7 view. White bar on bottom, header text in lousy location. 
+
+* CSS on SupportScreen is jacked on iPhone 7 view. White bar on bottom, header text in lousy location. 
+
+* CSS on PilotProfileWelcomeScreen (after completion) on iPhone 7 is jacked. Can't see below "No Industry Details"
+
+* MessagingScreen functional, albiet a little bland? Anyone got an idea to gussy it up?
+
+* Bug on ClientLocationPicker. Intial state is set to "where is the location of your drone service" of in TextInput when it should be blank. 
+
+* ClientNewProjectScreen forms
+PilotProfileSetupPageOne forms
+
+ - change modal to cover either more of the screen or blur the background upon opening. 
+ - make a Choose Button as opposed to "choose" text??
+
+ * Fix part-time uploader. Probably wait for Franks refactor. 
+
+ * Top gray framing bar on Pilot side is off.
+
+ * Back Button on Pilot Profile is Unclickable iPhone 7

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 * ~~keyboard needs to push forms up~~
 
 ### Both
-* auth headers need to be sorted out
+* auth headers need to be sorted out - Back button upon Sign up goes back to Landing page as oppsed to signin Screen. 
 
 
 ## Other Bugs
@@ -81,4 +81,10 @@ PilotProfileSetupPageOne forms
 
  * Top gray framing bar on Pilot side is off.
 
- * Back Button on Pilot Profile is Unclickable iPhone 7
+ * APP BREAKING ISSUE: Back Button on PilotProfile is Unclickable iPhone 7 
+
+ * Weird hiccup in Subheader CSS when navigating from ProjectsListScreen to MyJobsScreen - the subheader "clicks" down on animation...
+
+ * on JobDetailsScreen on Pilot Side, back button is pushed down so "Back" is unclickable if a job description details are too long. Wrap page in <ScrollView>????
+
+ * ChatScreen Input should be sticky / static and independant of the <ScrollView>

--- a/components/ClientLocationPicker.js
+++ b/components/ClientLocationPicker.js
@@ -64,7 +64,7 @@ const ClientLocationPicker = () => {
         transparent={true}
         visible={isModalVisible}
         animationType={APP_STRINGS.slide}
-        onRequestClose={() => closeModal()}
+        onRequestClose={closeModal}
       >
         <View style={styles.modalContainer}>
           <View style={styles.innerContainer}>
@@ -119,6 +119,13 @@ const styles = StyleSheet.create({
   buttonText: {
     color: "white",
     fontSize: 20,
+  },
+  input: {
+    marginTop: 20,
+    height: 90,
+    borderColor: "gray",
+    borderWidth: 1,
+    marginBottom: 20,
   },
 });
 

--- a/screens/pilot/JobListScreen.js
+++ b/screens/pilot/JobListScreen.js
@@ -89,10 +89,10 @@ function JobListScreen(
       ) : (
         <Text></Text>
       )}
-      <ScrollView>
         <View style={styles.subheaderWrapper}>
           <PilotSubheader />
         </View>
+      <ScrollView>
         <View style={styles.projectCard}>
           <TouchableOpacity>
             <FlatList
@@ -174,7 +174,6 @@ const styles = StyleSheet.create({
   },
   projectListWrapper: {
     alignItems: "center",
-    marginTop: 10,
   },
   profileCompleteNotice: {
     flexDirection: "row",
@@ -207,8 +206,8 @@ const styles = StyleSheet.create({
     fontWeight: "600",
   },
   subheaderWrapper: {
-    marginBottom: 10,
-    marginLeft: "5%",
+    marginBottom: 14,
+
   },
 });
 

--- a/screens/pilot/JobListScreen.js
+++ b/screens/pilot/JobListScreen.js
@@ -164,16 +164,12 @@ const styles = StyleSheet.create({
   projectCard: {
     width: 380,
   },
-  clientText: {
-    fontSize: 30,
-    color: "darkblue",
-    textAlign: "center",
-  },
   ClientProjectListTextWrapper: {
     marginBottom: 20,
   },
   projectListWrapper: {
     alignItems: "center",
+    
   },
   profileCompleteNotice: {
     flexDirection: "row",

--- a/screens/pilot/MyJobsScreen.js
+++ b/screens/pilot/MyJobsScreen.js
@@ -19,6 +19,7 @@ import { useNavigation } from '@react-navigation/native';
 import { getProjects } from "../../actions/projects";
 import * as firebase from 'firebase';
 import _ from "lodash";
+import PilotSubheader from '../../components/pilot/PilotSubheader'
 
 function MyJobsScreen(props, { getProjects }) {
 
@@ -41,74 +42,85 @@ function MyJobsScreen(props, { getProjects }) {
 
   return (
     <View style={styles.projectListWrapper}>
-      <ScrollView>
-        <View style={styles.projectCard}>
-          <TouchableOpacity>
-            <FlatList
-              style={{ width: "100%" }}
-              data={listOfMyProjects}
-              // showsVerticalScrollIndicator={true}
-              keyExtractor={item => item.key}
-              renderItem={({ item }) => {
-                return (
-                  <View
-                    style={{
-                      elevation: 8,
-                      borderRadius: 15,
-                      backgroundColor: "#092455",
-                      marginBottom: 15,
-                      padding: 20
-                    }}
-                  >
-                    <TouchableHighlight
-                      onPress={() =>
-                        props.navigation.navigate(
-                          "JobDetailsScreen",
-                          {
-                            ...item
-                          }
-                        )
-                      }
+      <PilotSubheader />
+      <View style={styles.scrollViewWrapper}>
+        <ScrollView>
+          <View style={styles.projectCard}>
+            <TouchableOpacity>
+              <FlatList
+                style={{ width: "100%" }}
+                data={listOfMyProjects}
+                // showsVerticalScrollIndicator={true}
+                keyExtractor={(item) => item.key}
+                renderItem={({ item }) => {
+                  return (
+                    <View
+                      style={{
+                        elevation: 8,
+                        borderRadius: 15,
+                        backgroundColor: "#092455",
+                        marginBottom: 15,
+                        padding: 20,
+                      }}
                     >
-                      <View>
-                        <Text style={{ color: "white", fontWeight: "800" }}>
-                          Location: {item.location}{" "}
-                        </Text>
-                        <Text style={{ color: "white", fontWeight: "800" }}>
-                          Date: {item.date}{" "}
-                        </Text>
-                        <Text style={{ color: "white", fontWeight: "800" }}>
-                          Recording: {item.recording}{" "}
-                        </Text>
-                      </View>
-                    </TouchableHighlight>
-                  </View>
-                );
-              }}
-            />
-          </TouchableOpacity>
-        </View>
-      </ScrollView>
+                      <TouchableHighlight
+                        onPress={() =>
+                          props.navigation.navigate("JobDetailsScreen", {
+                            ...item,
+                          })
+                        }
+                      >
+                        <View className={styles.jobWrapper}>
+                          <Text style={{ color: "white", fontWeight: "800" }}>
+                            Location: {item.location}{" "}
+                          </Text>
+                          <Text style={{ color: "white", fontWeight: "800" }}>
+                            Date: {item.date}{" "}
+                          </Text>
+                          <Text style={{ color: "white", fontWeight: "800" }}>
+                            Recording: {item.recording}{" "}
+                          </Text>
+                        </View>
+                      </TouchableHighlight>
+                    </View>
+                  );
+                }}
+              />
+            </TouchableOpacity>
+          </View>
+        </ScrollView>
+      </View>
     </View>
   );
 };
 
 const styles = StyleSheet.create({
   projectCard: {
-    width: 380
+    width: 380,
+    marginTop: 15,
   },
   clientText: {
     fontSize: 30,
     color: "darkblue",
-    textAlign: "center"
+    textAlign: "center",
   },
   ClientProjectListTextWrapper: {
-    marginBottom: 20
+    marginBottom: 20,
   },
   projectListWrapper: {
     alignItems: "center",
-    marginTop: 10
-  }
+    marginTop: 13,
+  },
+  scrollViewWrapper: {
+    alignItems: "center",
+
+
+  },
+  subheaderWrapper: {
+    marginBottom: 500,
+    marginLeft: "5%",
+  },
+  jobWrapper: {},
 });
 
 function mapStateToProps(state) {

--- a/screens/pilot/MyJobsScreen.js
+++ b/screens/pilot/MyJobsScreen.js
@@ -42,7 +42,9 @@ function MyJobsScreen(props, { getProjects }) {
 
   return (
     <View style={styles.projectListWrapper}>
-      <PilotSubheader />
+      <View style={styles.subheaderWrapper}>
+        <PilotSubheader />
+      </View>
       <View style={styles.scrollViewWrapper}>
         <ScrollView>
           <View style={styles.projectCard}>
@@ -97,15 +99,6 @@ function MyJobsScreen(props, { getProjects }) {
 const styles = StyleSheet.create({
   projectCard: {
     width: 380,
-    marginTop: 15,
-  },
-  clientText: {
-    fontSize: 30,
-    color: "darkblue",
-    textAlign: "center",
-  },
-  ClientProjectListTextWrapper: {
-    marginBottom: 20,
   },
   projectListWrapper: {
     alignItems: "center",
@@ -113,14 +106,10 @@ const styles = StyleSheet.create({
   },
   scrollViewWrapper: {
     alignItems: "center",
-
-
   },
   subheaderWrapper: {
-    marginBottom: 500,
-    marginLeft: "5%",
+    marginBottom: 14,
   },
-  jobWrapper: {},
 });
 
 function mapStateToProps(state) {


### PR DESCRIPTION
Clean up CSS on MyJobsScreen and JobListScreen. A bunch of unused code floating around. 

Bring Subheader wrapper outside of <ScrollView> so the header itself remains static on both MyJobsScreen and JobListScreen upon scrolling. 

Tweak CSS on both MJS and JLS so they are both uniform when switching between the two. Likely will only apply to the iPhone 7.. 