### PR TITLE
Style edit projects

### DIFF
--- a/components/client/ClientLightPicker.js
+++ b/components/client/ClientLightPicker.js
@@ -13,7 +13,7 @@ import {
   PassLightState,
 } from "../../screens/client/NewProjectScreenOne";
 import RadioForm from "react-native-simple-radio-button";
-import { APP_STRINGS } from "../constants/index";
+import { APP_STRINGS } from "../../constants/index";
 
 const ClientLightPicker = () => {
   const [isModalVisible, setIsModalVisible] = useState(false);
@@ -72,7 +72,7 @@ const ClientLightPicker = () => {
           <View styles={styles.cancelWrapper}>
           <TouchableOpacity style={styles.chatButton} onPress={() => setIsModalVisible(false)}>
               <Text style={styles.chatText}>{APP_STRINGS.save}</Text>
-            </TouchableOpacity> 
+            </TouchableOpacity>
           </View>
         </View>
       </Modal>
@@ -115,7 +115,7 @@ const styles = StyleSheet.create({
   },
   radiobutton: {
     paddingRight: '5%',
-  }, 
+  },
   input: {
     marginTop: 20,
     height: 90,

--- a/screens/client/ClientProfileScreen.js
+++ b/screens/client/ClientProfileScreen.js
@@ -8,8 +8,7 @@ import {
   Image,
   TouchableOpacity,
 } from "react-native";
-import { Ionicons } from "@expo/vector-icons";
-import { AntDesign } from "@expo/vector-icons";
+import { Ionicons, AntDesign } from "@expo/vector-icons";
 import personIcon from "../../assets/personIcon.png";
 import princePic01 from "../../assets/princePic01.jpg";
 import * as firebase from "firebase";

--- a/screens/client/EditProjectScreen.js
+++ b/screens/client/EditProjectScreen.js
@@ -21,83 +21,53 @@ function EditProjectScreen(props, { editProject }) {
   const [ recording, setRecording ] = useState(projectDetails.recording);
 
   const submit = (e) => {
+    projectDetails.location = location;
+    projectDetails.date = date;
+    projectDetails.recording = recording;
     props.editProject(location, date, recording, projectDetails.key);
-    navigation.navigate("ProjectListScreen");
+    navigation.navigate("ProjectDetailsScreen", {
+      ...projectDetails
+    });
   };
 
   return (
-    <KeyboardAwareScrollView style={styles.KeyboardAwareScrollView}>
-      <View style={styles.container}>
-        <View style={styles.editProjectCard}>
-          <Text style={styles.editProjectText}>
-            Edit Project
-            {"\n"}
-          </Text>
-          <Text style={styles.labelText}>Location</Text>
-          <TextInput
-            style={styles.input}
-            placeholderTextColor="white"
-            placeholder="location"
-            onChangeText={setLocation}
-            value={location}
-          />
-          <Text style={styles.labelText}>
-            {"\n"}
-            Date
-          </Text>
-          <TextInput
-            style={styles.input}
-            placeholderTextColor="white"
-            placeholder="date"
-            onChangeText={setDate}
-            value={date}
-          />
-          <Text style={styles.labelText}>
-            {"\n"}
-            Project Description
-          </Text>
-          <TextInput
-            style={styles.input}
-            placeholder="recording"
-            onChangeText={setRecording}
-            value={recording}
-          />
-        </View>
-        {/* <Button title="Save Changes" onPress={submit} /> */}
-
-        <View style={styles.submitButtonWrapper}>
-          <TouchableOpacity style={styles.submitButton} onPress={submit}>
-            <Text style={styles.submitButtonText}>Submit Update</Text>
-          </TouchableOpacity>
-        </View>
-
-        <View style={styles.backButtonWrapper}>
-          <TouchableOpacity
-            style={styles.backButton}
-            onPress={() => props.navigation.goBack()}
-          >
-            <Text style={styles.backButtonText}>Back</Text>
-          </TouchableOpacity>
-        </View>
-
-        {/* <Button title="Back" onPress={() => props.navigation.goBack()} /> */}
+    <View style={styles.container}>
+      <View style={styles.saveButton}>
+        <TouchableOpacity hitSlop={styles.hitSlop} onPress={submit}>
+          <Text style={styles.saveText}>Save changes</Text>
+        </TouchableOpacity>
       </View>
-    </KeyboardAwareScrollView>
+      <Text style={styles.ProjectText}>Edit Details</Text>
+      <View style={styles.line} />
+      <Text style={styles.detailsHeader}>Where</Text>
+      <TextInput
+        style={styles.DetailsText}
+        onChangeText={setLocation}
+        value={location}
+      />
+      <Text style={styles.detailsHeader}>When</Text>
+      <TextInput
+        style={styles.DetailsText}
+        onChangeText={setDate}
+        value={date}
+      />
+      <Text style={styles.detailsHeader}>What</Text>
+      <TextInput
+        style={styles.DetailsText}
+        onChangeText={setRecording}
+        value={recording}
+      />
+    </View>
   );
 }
 
 const styles = StyleSheet.create({
   container: {
-    flex: 1,
-    justifyContent: "center",
-    padding: 30,
-    backgroundColor: "lightgray",
-    height: "100%",
+    padding: 20,
   },
   KeyboardAwareScrollView: {
     flex: 1,
     height: "120%",
-    backgroundColor: "lightgray",
   },
   editProjectCard: {
     borderRadius: 15,
@@ -161,6 +131,49 @@ const styles = StyleSheet.create({
   },
   backButtonWrapper: {
     alignItems: "center",
+  },
+  ProjectText: {
+    fontSize: 25,
+    fontWeight: "bold",
+    color: "#3E90D0",
+    marginBottom: 20,
+    marginTop: 10,
+    zIndex: 0
+  },
+  DetailsText: {
+    marginBottom: 20,
+    fontSize: 17,
+    color: "grey",
+    fontWeight: "800",
+  },
+  line: {
+    borderBottomColor: "lightgrey",
+    borderBottomWidth: 1,
+    marginBottom: 20,
+  },
+  detailsHeader: {
+    fontSize: 20,
+    fontWeight: "bold",
+  },
+  hitSlop: {
+    top: 30,
+    left: 30,
+    bottom: 30,
+    right: 30
+  },
+  saveText: {
+    fontWeight: "bold",
+    fontSize: 15,
+    color: "white",
+  },
+  saveButton: {
+    position: "absolute",
+    right: "6%",
+    top: "8%",
+    backgroundColor: "#092455",
+    padding: 7,
+    borderRadius: 5,
+    zIndex: 1
   },
 });
 

--- a/screens/client/ProjectDetailsScreen.js
+++ b/screens/client/ProjectDetailsScreen.js
@@ -8,6 +8,8 @@ import {
   TouchableOpacity,
   Image,
 } from "react-native";
+import { AntDesign } from "@expo/vector-icons";
+import * as firebase from "firebase";
 import { connect } from "react-redux";
 import { getPilotProfiles } from "../../actions/pilotProfiles";
 import _ from "lodash";
@@ -22,10 +24,13 @@ function ProjectDetailsScreen(props, { getPilotProfiles }) {
   }, []);
 
   let pilot = null;
+  let user = null;
 
-  if (
-    props.listOfPilotProfiles.find((x) => x.userID === projectDetails.pilotID)
-  ) {
+  if (firebase.auth().currentUser) {
+    user = firebase.auth().currentUser;
+  }
+
+  if (props.listOfPilotProfiles.find((x) => x.userID === projectDetails.pilotID)) {
     pilot = props.listOfPilotProfiles.find(
       (x) => x.userID === projectDetails.pilotID,
     );
@@ -33,6 +38,18 @@ function ProjectDetailsScreen(props, { getPilotProfiles }) {
 
   return (
     <View style={styles.container}>
+      {(user.uid === projectDetails.clientID) && (
+        <TouchableOpacity
+        style={styles.editIcon}
+        onPress={() =>
+          props.navigation.navigate("EditProjectScreen", {
+            ...projectDetails,
+          })
+        }
+        >
+          <AntDesign name="edit" size={40} />
+        </TouchableOpacity>
+      )}
       <Text style={styles.ProjectText}>Details:</Text>
       <View style={styles.line} />
       <Text style={styles.detailsHeader}>Where</Text>
@@ -105,6 +122,7 @@ const styles = StyleSheet.create({
     color: "#3E90D0",
     marginBottom: 20,
     marginTop: 10,
+    zIndex: 0
   },
   DetailsText: {
     marginBottom: 20,
@@ -167,6 +185,12 @@ const styles = StyleSheet.create({
   backButtonWrapper: {
     marginTop: 20,
     alignItems: "center",
+  },
+  editIcon: {
+    top: "4%",
+    position: "absolute",
+    right: "6%",
+    zIndex: 1
   },
 });
 

--- a/screens/client/ProjectListScreen.js
+++ b/screens/client/ProjectListScreen.js
@@ -51,95 +51,93 @@ function ProjectListScreen(props, { getProjects, getPilotProfiles }) {
       </TouchableOpacity>
       <ScrollView>
         <View style={styles.projectCard}>
-          <TouchableOpacity>
-            <FlatList
-              style={{ width: "100%" }}
-              data={listOfMyProjects}
-              keyExtractor={(item) => item.key}
-              renderItem={({ item }) => {
-                return (
+          <FlatList
+            style={{ width: "100%" }}
+            data={listOfMyProjects}
+            keyExtractor={(item) => item.key}
+            renderItem={({ item }) => {
+              return (
+                <View
+                  style={{
+                    borderRadius: 15,
+                    backgroundColor: "#092455",
+                    marginBottom: 15,
+                    padding: 20,
+                  }}
+                >
+                  <TouchableHighlight
+                    onPress={() =>
+                      props.navigation.navigate("ProjectDetailsScreen", {
+                        ...item,
+                      })}
+                  >
+                    <View>
+                      <Text style={{ color: "white", fontWeight: "800" }}>
+                        Location: {item.location}{" "}
+                      </Text>
+                      <Text style={{ color: "white", fontWeight: "800" }}>
+                        Date: {item.date}{" "}
+                      </Text>
+                      <Text style={{ color: "white", fontWeight: "800" }}>
+                        Recording: {item.recording}{" "}
+                      </Text>
+                      {item.pilotID &&
+                      props.listOfPilotProfiles.find(
+                        (x) => x.userID === item.pilotID,
+                      ) ? (
+                        <Text style={{ color: "white", fontWeight: "800" }}>
+                          Your pilot:{" "}
+                          {
+                            props.listOfPilotProfiles.find(
+                              (x) => x.userID === item.pilotID,
+                            ).pilotFirstName
+                          }{" "}
+                          {
+                            props.listOfPilotProfiles.find(
+                              (x) => x.userID === item.pilotID,
+                            ).pilotLastName
+                          }
+                        </Text>
+                      ) : (
+                        <Text style={{ color: "white", fontWeight: "800" }}>
+                          Pending pilot
+                        </Text>
+                      )}
+                    </View>
+                  </TouchableHighlight>
                   <View
                     style={{
-                      borderRadius: 15,
-                      backgroundColor: "#092455",
-                      marginBottom: 15,
-                      padding: 20,
+                      flexDirection: "row",
+                      justifyContent: "flex-end",
+                      marginTop: 25,
                     }}
                   >
                     <TouchableHighlight
                       onPress={() =>
-                        props.navigation.navigate("ProjectDetailsScreen", {
+                        props.navigation.navigate("EditProjectScreen", {
                           ...item,
                         })}
                     >
-                      <View>
-                        <Text style={{ color: "white", fontWeight: "800" }}>
-                          Location: {item.location}{" "}
-                        </Text>
-                        <Text style={{ color: "white", fontWeight: "800" }}>
-                          Date: {item.date}{" "}
-                        </Text>
-                        <Text style={{ color: "white", fontWeight: "800" }}>
-                          Recording: {item.recording}{" "}
-                        </Text>
-                        {item.pilotID &&
-                        props.listOfPilotProfiles.find(
-                          (x) => x.userID === item.pilotID,
-                        ) ? (
-                          <Text style={{ color: "white", fontWeight: "800" }}>
-                            Your pilot:{" "}
-                            {
-                              props.listOfPilotProfiles.find(
-                                (x) => x.userID === item.pilotID,
-                              ).pilotFirstName
-                            }{" "}
-                            {
-                              props.listOfPilotProfiles.find(
-                                (x) => x.userID === item.pilotID,
-                              ).pilotLastName
-                            }
-                          </Text>
-                        ) : (
-                          <Text style={{ color: "white", fontWeight: "800" }}>
-                            Pending pilot
-                          </Text>
-                        )}
+                      <View style={{ marginRight: 15 }}>
+                        <FontAwesome5 name="edit" size={32} color="#a9b8de" />
                       </View>
                     </TouchableHighlight>
-                    <View
-                      style={{
-                        flexDirection: "row",
-                        justifyContent: "flex-end",
-                        marginTop: 25,
-                      }}
+                    <TouchableHighlight
+                      onPress={() => props.deleteProject(item.key)}
                     >
-                      <TouchableHighlight
-                        onPress={() =>
-                          props.navigation.navigate("EditProjectScreen", {
-                            ...item,
-                          })}
-                      >
-                        <View style={{ marginRight: 15 }}>
-                          <FontAwesome5 name="edit" size={32} color="#a9b8de" />
-                        </View>
-                      </TouchableHighlight>
-                      <TouchableHighlight
-                        onPress={() => props.deleteProject(item.key)}
-                      >
-                        <View>
-                          <MaterialCommunityIcons
-                            name="delete"
-                            size={32}
-                            color="#a9b8de"
-                          />
-                        </View>
-                      </TouchableHighlight>
-                    </View>
+                      <View>
+                        <MaterialCommunityIcons
+                          name="delete"
+                          size={32}
+                          color="#a9b8de"
+                        />
+                      </View>
+                    </TouchableHighlight>
                   </View>
-                );
-              }}
-            />
-          </TouchableOpacity>
+                </View>
+              );
+            }}
+          />
         </View>
       </ScrollView>
     </View>
@@ -148,7 +146,7 @@ function ProjectListScreen(props, { getProjects, getPilotProfiles }) {
 
 const styles = StyleSheet.create({
   projectCard: {
-    width: 380,
+    width: "95%",
     marginBottom: 140,
   },
   clientText: {

--- a/screens/pilot/JobListScreen.js
+++ b/screens/pilot/JobListScreen.js
@@ -172,6 +172,7 @@ const styles = StyleSheet.create({
   projectCard: {
     width: 380,
     marginTop: 15,
+    marginBottom: 100
   },
   ClientProjectListTextWrapper: {
     marginBottom: 20,


### PR DESCRIPTION
This pull request adds mostly styling tweaks.

On the edit project screen, I made it look very similar to the project details.

Before:
![hovrtek-before](https://user-images.githubusercontent.com/56557407/84444248-9484de80-abfe-11ea-85c1-02f940871002.png)

And after:
![hovrtek-after](https://user-images.githubusercontent.com/56557407/84444274-a797ae80-abfe-11ea-8cfa-b6d821940846.png)

I also added a function to pass props back from the edit project screen to the project details screen so you can navigate between the two while updating them
