### PR TITLE
fix edit project navigation so whether you edit from the list screen …

### DIFF
--- a/screens/client/EditProjectScreen.js
+++ b/screens/client/EditProjectScreen.js
@@ -15,7 +15,8 @@ import {API_KEY} from "../../geocoder"
 Geocoder.init(API_KEY);
 
 function EditProjectScreen(props, { editProject }) {
-  const projectDetails = props.route.params;
+  const { projectDetails } = props.route.params;
+  const { fromList } = props.route.params;
   const navigation = useNavigation();
 
   const [ location, setLocation ] = useState(projectDetails.location);
@@ -30,7 +31,6 @@ function EditProjectScreen(props, { editProject }) {
     if(location != projectDetails.location){
       let locationCoordinatesResponse = await convertLocation(location)
       locationCoordinates = locationCoordinatesResponse
-      console.log("SHOUT IT FROM THE ROOFTOPS")
     } else {
       locationCoordinates = projectDetails.locationCoordinates
     }
@@ -38,8 +38,8 @@ function EditProjectScreen(props, { editProject }) {
     projectDetails.date = date;
     projectDetails.recording = recording;
     props.editProject(location, date, recording, locationCoordinates, projectDetails.key);
-    navigation.navigate("ProjectDetailsScreen", {
-      ...projectDetails
+    fromList ? navigation.navigate("ProjectListScreen") :
+    navigation.navigate("ProjectDetailsScreen", { projectDetails: projectDetails
     });
     setLoadingActive(false)
   };

--- a/screens/client/ProjectDetailsScreen.js
+++ b/screens/client/ProjectDetailsScreen.js
@@ -43,7 +43,8 @@ function ProjectDetailsScreen(props, { getPilotProfiles }) {
         style={styles.editIcon}
         onPress={() =>
           props.navigation.navigate("EditProjectScreen", {
-            ...projectDetails,
+            projectDetails: projectDetails,
+            fromList: false
           })
         }
         >

--- a/screens/client/ProjectListScreen.js
+++ b/screens/client/ProjectListScreen.js
@@ -113,7 +113,8 @@ function ProjectListScreen(props, { getProjects, getPilotProfiles }) {
                       <TouchableHighlight
                         onPress={() =>
                           props.navigation.navigate("EditProjectScreen", {
-                            ...item,
+                            projectDetails: item,
+                            fromList: true
                           })}
                       >
                         <View style={{ marginRight: 15 }}>


### PR DESCRIPTION
Edit project navigation on the client side is now fixed.  Whether you click to edit a project straight from the list or from the details screen, now you are returned to the same screen after clicking save changes